### PR TITLE
usmetadata_filter sometimes gets non-string argument

### DIFF
--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -16,6 +16,7 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as p
 import db_utils
+
 from ckan.common import _, json, request, c, g, response, is_flask_request, config
 from ckan.lib.base import BaseController
 
@@ -565,7 +566,8 @@ class CommonCoreMetadataFormPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetFo
         return None
 
     @classmethod
-    def usmetadata_filter(cls, data=None, mask='~~'):
+    def usmetadata_filter(cls, data='', mask='~~'):
+        data = unicode(data)  # get rid of None, True, etc.
         for redact in re.findall(REDACTION_STROKE_REGEX, data):
             data = data.replace(redact, mask)
         data = data.replace('[[/REDACTED]]', mask)

--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -16,7 +16,6 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as p
 import db_utils
-
 from ckan.common import _, json, request, c, g, response, is_flask_request, config
 from ckan.lib.base import BaseController
 


### PR DESCRIPTION
For example, in
File '/usr/lib/ckan/venv/src/ckanext-usmetadata/ckanext/usmetadata/templates/package/resource_read.h
tml', line 131 in block "resource_additional_information":
 <span class="redacted-md">{{ h.usmetadata_filter(value) }}</span>

the value could be None or True. Then, it is used in  re.findall(REDACTION_STROKE_REGEX, value) and as a result, there is a Server Error (TypeError: expected string or buffer).